### PR TITLE
Ext app loading changes: Future-proof y-axis sizing issues

### DIFF
--- a/src/components/ExtensionApp.scss
+++ b/src/components/ExtensionApp.scss
@@ -5,7 +5,7 @@ body,
 #root {
   margin: 0;
   padding: 0;
-  height: 100%;
+  height: 100vh;
 }
 
 .bqml-app {
@@ -17,7 +17,7 @@ body,
   position: relative;
   z-index: 0;
   flex-direction: column;
-  height: 100%;
+  height: 100vh;
   width: 100vw;
 
   * {

--- a/src/components/QueryBuilder/Expander/ExpanderBar.scss
+++ b/src/components/QueryBuilder/Expander/ExpanderBar.scss
@@ -1,6 +1,6 @@
 .ExpanderBarContents__container {
   .expander--open {
-    height: 100%;
+    height: 100vh;
   }
 
   &:first-child .expander-body {

--- a/src/components/QueryBuilder/ResultsTable/ResultsTable.scss
+++ b/src/components/QueryBuilder/ResultsTable/ResultsTable.scss
@@ -18,7 +18,7 @@
     width: 100%;
     align-items: center;
     justify-content: center;
-    height: 100%;
+    height: 100vh;
     background-color: rgba(255, 255, 255, .5);
   }
 


### PR DESCRIPTION
JIRA: https://4mile.atlassian.net/browse/BQML-60

Some potential breaking changes are coming due to the fact that [Looker is changing how extension apps are loaded](https://help.looker.com/hc/en-us/articles/4634096894995-Testing-the-new-extension-framework-loader). In trying to test and find possible breaks, we've found that mainly these minor y-axis sizing issues will come up, so let's try and future-proof against these before the loading process changes.