### PR TITLE
Add labels to confusion matrix (actual vs predicted values)

### DIFF
--- a/src/components/Step4/ModelDataBody.tsx
+++ b/src/components/Step4/ModelDataBody.tsx
@@ -65,7 +65,7 @@ const ConfusionMatrixTable: React.FC<{ data: any[], target?: string }> = ({ data
   })()
 
   const headers = [(
-    <td className="model-cm-item--placeholder" width="60" key="placeholder"></td>
+    <td colSpan={2} className="model-cm-item--placeholder" width="60" key="placeholder"></td>
   )]
 
   for (const row of sortedData) {
@@ -74,9 +74,23 @@ const ConfusionMatrixTable: React.FC<{ data: any[], target?: string }> = ({ data
     )
   }
 
-  const tableHeader = (
+  // Add col header (label for actual values)
+  const tableHeader = [(
+    <tr>
+      <th colSpan={sortedData.length + 2}>Actual Values</th>
+    </tr>
+  )]
+
+  tableHeader.push(
     <tr className="model-cm-item" key={'headers'}>
       {headers}
+    </tr>
+  )
+
+  // Add row header (label for predicted values)
+  dataItems.push(
+    <tr>
+      <th className='rotate' rowSpan={sortedData.length + 2}>Predicted Values</th>
     </tr>
   )
 

--- a/src/components/Step4/Step4.scss
+++ b/src/components/Step4/Step4.scss
@@ -218,6 +218,10 @@
   }
 }
 
+.rotate {
+  transform: rotate(-90deg);
+}
+
 .binary-classifier-container {
   padding: 12px;
   margin-top: 8px;


### PR DESCRIPTION
JIRA issue: https://4mile.atlassian.net/browse/BQML-55

Add labels to confusion matrix table ("x-axis" == actual values, "y-axis" == predicted values). Minimal basic styling for now, just to rotate text for y-axis label.