### PR TITLE
BQML-64 Show viz panel on Source tab and hide on Predict tab

### DIFF
--- a/src/components/QueryBuilder/QueryPane/QueryPane.tsx
+++ b/src/components/QueryBuilder/QueryPane/QueryPane.tsx
@@ -52,7 +52,7 @@ export const QueryPane: React.FC = () => {
           </div>
         </ExpanderBar>
       }
-      { stepName === 'step5' &&
+      { stepName === 'step2' &&
         <ExpanderBar
           title="Visualization"
           expanderBodyClasses="filter-expander"

--- a/src/components/Visualizations/VizChart.tsx
+++ b/src/components/Visualizations/VizChart.tsx
@@ -26,7 +26,7 @@ export const VizChart : React.FC<VizChartProps> = ({ ranQuery, type }) => {
   }, [type, data])
 
   const buildChartObj = () => {
-    if (!ranQuery || !target) { return }
+    if (!ranQuery) { return }
 
     switch (type) {
       case 'line':

--- a/src/services/visualizations/visualizations.ts
+++ b/src/services/visualizations/visualizations.ts
@@ -23,10 +23,13 @@ export const buildVizDataSets = ({ ranQuery, data, target, labels, datasetMapper
   if (measures.length > 0) {
     chartMeasures.push(...measures)
   }
-  const targetIndex = chartMeasures.indexOf(target)
-  if (targetIndex < 0) {
-    // insert the target if its a dimension
-    chartMeasures.splice(1, 0, target)
+
+  if (target) {
+    const targetIndex = chartMeasures.indexOf(target)
+    if (targetIndex < 0) {
+      // insert the target if its a dimension
+      chartMeasures.splice(1, 0, target)
+    }
   }
 
   const datasetColors = getDatasetColors(chartMeasures.length)
@@ -48,16 +51,18 @@ export const buildVizDataSets = ({ ranQuery, data, target, labels, datasetMapper
 export const buildVizLabels = (ranQuery: RanQuery, data: any, target: string) => {
   if (!ranQuery?.selectedFields) { return [] }
   const dimensions = [...ranQuery.selectedFields.dimensions]
-  const targetIndex = dimensions.indexOf(target)
 
-  if (targetIndex >= 0) {
-    dimensions.splice(targetIndex, 1)
+  if (target) {
+    const targetIndex = dimensions.indexOf(target)
+    if (targetIndex >= 0) {
+      dimensions.splice(targetIndex, 1)
+    }
   }
 
   return data.map((datum: any) => {
     let label = ""
     dimensions.forEach((dim) => {
-      if (label) { label += " - "}
+      if (label) { label += " - " }
       label += datum[dim] ? datum[dim].value : ''
     })
     return label


### PR DESCRIPTION
JIRA issue https://4mile.atlassian.net/browse/BQML-64

For beta release, client would like to hide viz panel on 'Predict' tab Explore. Client also wants to add viz panel to the Explore on 'Source' tab. Making this addition minimally for now but leaving in code needed for display on 'Predict' tab, for when this is restored and enhanced in a future release.