### PR TITLE
BQML-68 Change summary stats input data table generation strategy

### DIFF
--- a/src/contexts/SummaryProvider.tsx
+++ b/src/contexts/SummaryProvider.tsx
@@ -104,15 +104,31 @@ export const SummaryProvider = ({ children }: any) => {
       }
 
       let inputDataUID = state.bqModel.inputDataUID
+
+      // second condition here is for backwards compatibility with old models,
+      // when a UID strategy was being used (rather than a/b alternation)
+      if(!inputDataUID || (inputDataUID != "a" && inputDataUID != "b")) {
+        // Create "a" table on first run
+        setPreviousBQValues({
+          sql: querySql,
+          model: bqModelName
+        })
+        const result = await createBQInputData(querySql, bqModelName, "a")
+        if (!result.ok) {
+          throw "Failed to create BQML View"
+        }
+
+        // initialize to start on "a" table
+        inputDataUID = "a"
+      }
+
       // in an effort to limit the number of calls to BigQuery
-      // do not create the input_data table if its alrady been created for this sql and model name
+      // do not create the input_data table if it's already been created for this sql and model name
       if (querySql &&
         (querySql !== previousBQValues.sql || bqModelName !== previousBQValues.model || !summaryUpToDate)
       ) {
-        // Using a UID we create a new input data table everytime "Generate Summary" is clicked.
-        // This allows the input_data table (summary table) to be out of sync with the model.
-        // So, when reloading a past model it will grab the correct version of the input_data
-        inputDataUID = uuidv4().replace(/\-/g, '') // generate a new UID (uuid no hyphens) to save a new input_data table
+        // switch to whichever table is not currently locked to model to write new summary 'snapshot'
+        inputDataUID = (inputDataUID === "b") ? "a" : "b"
         setPreviousBQValues({
           sql: querySql,
           model: bqModelName

--- a/src/types/bqModelState.ts
+++ b/src/types/bqModelState.ts
@@ -7,7 +7,7 @@ export type BQModelState = {
   arimaTimeColumn?: string,
   selectedFeatures?: string[],
   advancedSettings?: any,
-  inputDataUID?: string,
+  inputDataUID?: "a" | "b",
   inputDataQuery: {
     exploreName?: string,
     modelName?: string,


### PR DESCRIPTION
JIRA issue: https://4mile.atlassian.net/browse/BQML-68

Changes the strategy being used to handle generating input data tables. Previously used strategy generated a new table and appended a unique ID every time summary stats were generated. This caused new tables to be created over and over and not cleaned up, potentially cluttering BQ with lots of cruft.

New strategy just creates two input data tables ("A" and "B") for a model and alternates between the two of them: one is always associated with the model and reflects its actual state, while the other is a sort of temp/staging table where new summary stats are written before the model is re-created. This allows for the user to explore their data but not necessarily apply the changes to the model. Only upon model re-creation, the two tables are swapped so that the "temp" becomes associated with the model and reflects the new state of the model, and the other table will be there to serve the "temp" function should summary be generated again.